### PR TITLE
Add fasta-fetcher applet

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,7 @@ To incorporate code changes from [upstream](https://github.com/broadinstitute/vi
 
 1. Rebase the `dnanexus-resources-tarball` branch (specifically, the commit modifying `.travis.yml` as described above) on top of the desired upstream revision/tag, and (force) push to GitHub.
 2. Take note of the file ID of the new tarball Travis then generates in [bi-viral-ngs CI:/resources_tarball](https://platform.dnanexus.com/projects/BXBXK180x0z7x5kxq11p886f/data/resources_tarball)
-3. On the `dnanexus` branch (or wip branches from it), find the `resources` input in `viral-ngs-human-depletion/dxapp.json`, and change its default to the new tarball's file ID. (All the other workflow stages take the cue from this default setting.)
+3. On the `dnanexus` branch (or wip branches from it), find the `resources` input in both `viral-ngs-human-depletion/dxapp.json` and `viral-ngs-fasta-fetcher/dxapp.json`, and change their default to the new tarball's file ID. (All the other workflow stages take the cue from default setting in `viral-ngs-human-depletion`.)
 4. Ensure Travis tests succeed using the new version.
 
 ### Software licensing issues

--- a/build_assembly_workflow.py
+++ b/build_assembly_workflow.py
@@ -41,14 +41,26 @@ print "project: {} ({})".format(project.name, args.project)
 print "folder: {}".format(args.folder)
 
 def build_applets():
-    applets = ["viral-ngs-human-depletion", "viral-ngs-filter", "viral-ngs-trinity", "viral-ngs-assembly-scaffolding", "viral-ngs-assembly-refinement", "viral-ngs-assembly-analysis"]
+    applets = ["viral-ngs-human-depletion", "viral-ngs-filter", "viral-ngs-trinity", "viral-ngs-assembly-scaffolding",
+               "viral-ngs-assembly-refinement", "viral-ngs-assembly-analysis"]
 
+    # Build applets for assembly workflow in [args.folder]/applets/ folder
     project.new_folder(applets_folder, parents=True)
     for applet in applets:
         # TODO: reuse an existing applet with matching git_revision
         print "building {}...".format(applet),
         sys.stdout.flush()
         applet_dxid = json.loads(subprocess.check_output(["dx","build","--destination",args.project+":"+applets_folder+"/",os.path.join(here,applet)]))["id"]
+        print applet_dxid
+        applet = dxpy.DXApplet(applet_dxid, project=project.get_id())
+        applet.set_properties({"git_revision": git_revision})
+
+    # Build applets that user interact with directly in [args.folder]/ main folder
+    exposed_applets = ["viral-ngs-fasta-fetcher"]
+    for applet in exposed_applets:
+        print "building {}...".format(applet),
+        sys.stdout.flush()
+        applet_dxid = json.loads(subprocess.check_output(["dx","build","--destination",args.project+":"+args.folder+"/",os.path.join(here,applet)]))["id"]
         print applet_dxid
         applet = dxpy.DXApplet(applet_dxid, project=project.get_id())
         applet.set_properties({"git_revision": git_revision})
@@ -69,7 +81,7 @@ def build_workflow():
                               project=args.project,
                               folder=args.folder,
                               properties={"git_revision": git_revision})
-    
+
     depletion_applet = find_applet("viral-ngs-human-depletion")
     depletion_applet_inputSpec = depletion_applet.describe()["inputSpec"]
     depletion_input = {
@@ -234,7 +246,7 @@ if args.run_tests is True or args.run_large_tests is True:
         alignment_base_count = test_analysis.describe()["output"][workflow.get_stage("analysis")["id"]+".alignment_base_count"]
         expected_alignment_base_count = test_samples[test_sample]["expected_alignment_base_count"]
         print "\t".join([test_sample, "alignment_base_count", str(expected_alignment_base_count), str(alignment_base_count)])
-        
+
         assert expected_sha256sum == test_assembly_sha256sum
         assert expected_subsampled_base_count == subsampled_base_count
         assert expected_alignment_base_count == alignment_base_count

--- a/viral-ngs-fasta-fetcher/Readme.md
+++ b/viral-ngs-fasta-fetcher/Readme.md
@@ -1,0 +1,11 @@
+# Viral NGS Fasta Fetcher
+
+## What does this applet do?
+
+This applet fetches genomic fasta files for organisms of given accession numbers from Genbank.
+
+## Parameters
+- resources: The tarball containing resources from the [viral-ngs project](https://github.com/broadinstitute/viral-ngs). This is typically pre-filled for your convenience.
+- accession_numbers: A list of NCBI accession numbers corresponding to the organisms/strains whose genomic fasta files are to be fetched. This can be provided as a space-delimited (NC_004296.1 NC_004297.1) or comma-delimited (NC_004296.1, NC_004297.1) string.
+- user_email: A valid email address is requested by NCBI for load/abuse notifications.
+- combined_genome_prefix: the output file will be named [combined_genome_prefix].fasta

--- a/viral-ngs-fasta-fetcher/dxapp.json
+++ b/viral-ngs-fasta-fetcher/dxapp.json
@@ -1,0 +1,51 @@
+{
+  "name": "viral-ngs-fasta-fetcher",
+  "title": "fetch_fasta",
+  "summary": "Fetch genomic fasta from Genbank based on accession numbers",
+  "dxapi": "1.0.0",
+  "version": "0.0.1",
+  "categories": [],
+  "inputSpec": [
+    {
+      "name": "accession_numbers",
+      "label": "Genbank accession numbers",
+      "class": "array:string",
+      "optional": false
+    },
+    {
+      "name": "combined_genome_prefix",
+      "label": "Prefix given to combined fasta file",
+      "class": "string",
+      "optional": false
+    },
+    {
+      "name": "user_email",
+      "label": "Email address passed to NCBI for notification of excessive requests",
+      "class": "string",
+      "optional": false
+    },
+    {
+      "name": "resources",
+      "class": "file",
+      "patterns": ["viral-ngs-*.resources.tar.gz"],
+      "default": {"$dnanexus_link": "file-Bg2VBvj0vFx512Ky6VG493Yz"}
+    }
+  ],
+  "outputSpec": [
+    {
+      "name": "genome_fasta",
+      "label": "Combined genome fasta",
+      "class": "file"
+    }
+  ],
+  "runSpec": {
+    "interpreter": "bash",
+    "file": "src/viral-ngs-fasta-fetcher.sh"
+  },
+  "access": {
+    "network": [
+      "*"
+    ]
+  },
+  "authorizedUsers": []
+}

--- a/viral-ngs-fasta-fetcher/src/viral-ngs-fasta-fetcher.sh
+++ b/viral-ngs-fasta-fetcher/src/viral-ngs-fasta-fetcher.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+main() {
+    set -e -x -o pipefail
+
+    accessions=$(echo ${accession_numbers[*]})
+    dx cat "$resources" | tar zx -C /
+
+    # Write combined fasta to /genome.fasta
+    viral-ngs/ncbi.py fetch_fastas_and_feature_tables $user_email ./ $accessions --combinedGenomeFilePrefix genome --removeSeparateFastas
+
+    genome_fasta=$(dx upload genome.fasta --destination "${combined_genome_prefix}.fasta" --brief)
+
+    dx-jobutil-add-output genome_fasta "$genome_fasta" --class=file
+}


### PR DESCRIPTION
@alphabdiallo 
cc @mlin 

Adds an applet, `ngs-viral-fasta-fetcher`, to the ngs-viral project. This applet is a wrapper around the `ncbi.py fetch_fastas_and_feature_tables` function to fetch and combine fasta files from Genbank. This applet is meant to be used by users of the viral-ngs pipeline who want to work on assemblies beyond the Ebola and Lassa viruses.

Original request from Danny:
_...... as long as we have a small applet available for folks to fetch and build their own database for some other virus than Lassa or Ebola. Folks have noticed a number of other interesting viruses in our sequence data (GB virus C, Orungyo, etc) and the underlying code should be able to assemble those just fine as well._

The applet is built by `build_workflow.py` into the main target folder (not in the `applet` folder) so that it is directly visible to users. 

File structure and built applet: [example built applet](https://platform.dnanexus.com/projects/BXBXK180x0z7x5kxq11p886f/data/2015-08/14-182339-9a970ae)

Run: [example usage](https://platform.dnanexus.com/projects/BXBXK180x0z7x5kxq11p886f/monitor/job/Bg739P00x0z398vpG8Zj8gx3)

TODO:
Document this applet and its use case in wiki page.
