### PR TITLE
Multiple contig assembly on viral-ngs pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ script:
 - tar zxf dx-toolkit-current-ubuntu-12.04-amd64.tar.gz
 - source dx-toolkit/environment
 # pre-warm later workflow stages
-- for i in $(seq 1 3); do dx run --project-context-id project-BXBXK180x0z7x5kxq11p886f /assets/eval -i sh="sleep 1" --name "prewarming no-op" --instance-type mem1_ssd1_x4 --brief -y; done
+- for i in $(seq 1 2); do dx run --project-context-id project-BXBXK180x0z7x5kxq11p886f /assets/eval -i sh="sleep 1" --name "prewarming no-op" --instance-type mem1_ssd1_x4 --brief -y; done
 # execute workflow builder script
 - python build_assembly_workflow.py --species Ebola Lassa --run-tests
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ script:
 - tar zxf dx-toolkit-current-ubuntu-12.04-amd64.tar.gz
 - source dx-toolkit/environment
 # pre-warm later workflow stages
-- for i in $(seq 1 2); do dx run --project-context-id project-BXBXK180x0z7x5kxq11p886f /assets/eval -i sh="sleep 1" --name "prewarming no-op" --instance-type mem1_ssd1_x4 --brief -y; done
+- for i in $(seq 1 3); do dx run --project-context-id project-BXBXK180x0z7x5kxq11p886f /assets/eval -i sh="sleep 1" --name "prewarming no-op" --instance-type mem1_ssd1_x4 --brief -y; done
 # execute workflow builder script
-- python build_assembly_workflow.py --run-tests
+- python build_assembly_workflow.py --species Ebola Lassa --run-tests
 env:
   global:
   - secure: "hqaflXcPTtAoDDA/KmsTOT8P3tbRQoPLzpzN65UlN0ZlvMM61MjnY0fOQxKNLKrwgQzZWehNt/iXHkEvnYAQopUNlfQ7By5M1njFJSKbdix9UG+B4uF7/ERfxnT+F+AyXiJM974l6uvXAE5s3k7CVTwMol6Rx9XcEA7Sq5sVs/8="

--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,7 @@ To incorporate code changes from [upstream](https://github.com/broadinstitute/vi
 
 1. Rebase the `dnanexus-resources-tarball` branch (specifically, the commit modifying `.travis.yml` as described above) on top of the desired upstream revision/tag, and (force) push to GitHub.
 2. Take note of the file ID of the new tarball Travis then generates in [bi-viral-ngs CI:/resources_tarball](https://platform.dnanexus.com/projects/BXBXK180x0z7x5kxq11p886f/data/resources_tarball)
-3. On the `dnanexus` branch (or wip branches from it), find the `resources` input in `viral-ngs-human-depletion/dxapp.json`, and change its default to the new tarball's file ID. (All the other workflow stages take the cue from this default setting.)
+3. On the `dnanexus` branch (or wip branches from it), find the `resources` input in both `viral-ngs-human-depletion/dxapp.json` and `viral-ngs-fasta-fetcher/dxapp.json`, and change their default to the new tarball's file ID. (All the other workflow stages take the cue from default setting in `viral-ngs-human-depletion`.)
 4. Ensure Travis tests succeed using the new version.
 
 ### Software licensing issues

--- a/build_assembly_workflow.py
+++ b/build_assembly_workflow.py
@@ -205,20 +205,11 @@ if args.run_tests is True or args.run_large_tests is True:
             # contig is named >SRR1553554-0
             "expected_subsampled_base_count":  467842,
             "expected_alignment_base_count": 590547
-        },
-        "G1190": {
-            "species": "Lassa",
-            "reads": "file-Bg97bJQ0x0z12q4XyZf5p0Kk",
-            "broad_assembly": 'file-Bg533J00x0zBkYkFGb23k58B',
-            "expected_assembly_sha256sum": "e7aa592e5ab9d3d1d3ac7fa1cc53eeff37e3ea30afad72a3cf9549172767c95c",
-            # contig is named >G1190-0 and so on
-            "expected_subsampled_base_count":  1841634,
-            "expected_alignment_base_count": 111944259
         }
     }
 
     if args.run_large_tests is True:
-        # nb this sample takes too long for Travis
+        # nb these samples takes too long for Travis
         test_samples["SRR1553468"] = {
             "species": "Ebola",
             "reads": "file-BXYqZj80Fv4YqP151Zy9291y",
@@ -228,6 +219,15 @@ if args.run_tests is True or args.run_large_tests is True:
             # contig is named >SRR1553468-0
             "expected_subsampled_base_count": 18787806,
             "expected_alignment_base_count": 247110236
+        }
+        test_samples["G1190"] = {
+            "species": "Lassa",
+            "reads": "file-Bg97bJQ0x0z12q4XyZf5p0Kk",
+            "broad_assembly": 'file-Bg533J00x0zBkYkFGb23k58B',
+            "expected_assembly_sha256sum": "e7aa592e5ab9d3d1d3ac7fa1cc53eeff37e3ea30afad72a3cf9549172767c95c",
+            # contig is named >G1190-0 and so on
+            "expected_subsampled_base_count":  1841634,
+            "expected_alignment_base_count": 111944259
         }
 
     test_analyses = []
@@ -282,6 +282,7 @@ if args.run_tests is True or args.run_large_tests is True:
 
     # check figures of merit
     for (test_sample,test_analysis) in test_analyses:
+        workflow = workflows[test_samples[test_sample]["species"]]
         subsampled_base_count = test_analysis.describe()["output"][workflow.get_stage("trinity")["id"]+".subsampled_base_count"]
         expected_subsampled_base_count = test_samples[test_sample]["expected_subsampled_base_count"]
         print "\t".join([test_sample, "subsampled_base_count", str(expected_subsampled_base_count), str(subsampled_base_count)])

--- a/build_assembly_workflow.py
+++ b/build_assembly_workflow.py
@@ -97,7 +97,7 @@ def build_workflow():
 
     scaffold_input = {
         "trinity_contigs": dxpy.dxlink({"stage": trinity_stage_id, "outputField": "contigs"}),
-        "trinity_reads": dxpy.dxlink({"stage": trinity_stage_id, "inputField": "reads"}),
+        "trinity_reads": dxpy.dxlink({"stage": trinity_stage_id, "outputField": "subsampled_reads"}),
         "reference_genome" : dxpy.dxlink(args.scaffold_reference),
         "resources": dxpy.dxlink({"stage": depletion_stage_id, "inputField": "resources"})
     }

--- a/build_assembly_workflow.py
+++ b/build_assembly_workflow.py
@@ -148,9 +148,8 @@ if args.run_tests is True or args.run_large_tests is True:
             "reads": "file-BXBP0VQ011y0B0g5bbJFzx51",
             "reads2": "file-BXBP0Xj011yFYvPjgJJ0GzZB",
             "broad_assembly": "file-BXFqQvQ0QyB5859Vpx1j7bqq",
-            "expected_assembly_sha256sum": "411834d66c5226651493b9b921a157984db030a3a5d048975b709806228d3806",
-            # SHA256sum for fasta file with _scaffold suffix in contig name
-            # "expected_assembly_sha256sum": "20943d9e7e10208dd04cab6b9af2f27e8c924550921e0596fd4bddb1bfa827c1",
+            "expected_assembly_sha256sum": "0aee68fa7a120e6a319dea3f3fb6f74243d928e7c54023799ea16de6322c67da",
+            # contig is named >SRR1553416-0
             "expected_subsampled_base_count": 459632,
             "expected_alignment_base_count": 485406
         },
@@ -158,9 +157,8 @@ if args.run_tests is True or args.run_large_tests is True:
             "reads": "file-BXPPQ2Q0YzB28x9Q9911Ykz5",
             "reads2": "file-BXPPQ380YzB6xGxJ45K9Yv6Q",
             "broad_assembly": "file-BXQx6G00QyB6PQVYKQBgzxv4",
-            "expected_assembly_sha256sum": "af4328b04113a149e66055c113ef35fa566e691a2eabde85231ccf2a08df1bf4",
-            # SHA256sum for fasta file with _scaffold suffix in contig name
-            # "expected_assembly_sha256sum": "5893354fad5088d0731bd0e3b9427b0a175743d283469d687c5d5b2004f1da89",
+            "expected_assembly_sha256sum": "cdfeb7773bba47f72316dbd197b91130380ed9e165d5a1dde142257266092b54",
+            # contig is named >SRR1553554-0
             "expected_subsampled_base_count":  467842,
             "expected_alignment_base_count": 590547
         }
@@ -172,9 +170,8 @@ if args.run_tests is True or args.run_large_tests is True:
             "reads": "file-BXYqZj80Fv4YqP151Zy9291y",
             "reads2": "file-BXYqZkQ0Fv4YZYKx14yJg0b4",
             "broad_assembly": "file-BXYqYKQ0QyB84xYJP9Kz7zzK",
-            "expected_assembly_sha256sum": "456bd7e050222e0eff4fbe4a04c4124695c89d0533b318a49777789f3ed8bb2b",
-            # SHA256sum for fasta file with _scaffold suffix in contig name
-            # "expected_assembly_sha256sum": "4f851bfb1f3affd96e73dc20c4087e59908092a0354e3f00427c6bdfbf39d1a1",
+            "expected_assembly_sha256sum": "4460fbf7cc24e921e0eb3925713cc34fe58f6dfe9594954ff65da7cbcd71b093",
+            # contig is named >SRR1553468-0
             "expected_subsampled_base_count": 18787806,
             "expected_alignment_base_count": 247110236
         }

--- a/build_assembly_workflow.py
+++ b/build_assembly_workflow.py
@@ -8,24 +8,44 @@ import os
 import json
 import hashlib
 
+species_resource = {
+    'Ebola':{
+        'contaminants': 'file-BXF0vYQ0QyBF509G9J12g927',
+        'filter-targets': 'file-BXF0vf80QyBF509G9J12g9F2',
+        'scaffold-reference': 'file-BXF0vZ00QyBF509G9J12g944'
+    },
+    'Lassa':{
+        'contaminants': 'file-BXF0vYQ0QyBF509G9J12g927',
+        'filter-targets': 'file-Bg533J00x0zBkYkFGb23k58B',
+        'scaffold-reference': 'file-Bg533J00x0zBkYkFGb23k58B'
+    },
+    'Generic':{
+        'contaminants': 'file-BXF0vYQ0QyBF509G9J12g927'
+    }
+}
+valid_species = species_resource.keys()
+
 argparser = argparse.ArgumentParser(description="Build the viral-ngs assembly workflow on DNAnexus.")
 argparser.add_argument("--project", help="DNAnexus project ID", default="project-BXBXK180x0z7x5kxq11p886f")
 argparser.add_argument("--folder", help="Folder within project (default: timestamp-based)", default=None)
+argparser.add_argument("--species", help="Build workflow(s) by populating resources for the specified species. \
+                                    Allows for multiple species to be chosen. 'Generic' builds a workflow without chaining species-specific resource. Choices: %(choices)s",
+                                    nargs='+', choices=valid_species, default=["Generic"])
 argparser.add_argument("--no-applets", help="Assume applets already exist under designated folder", action="store_true")
-argparser.add_argument("--contaminants", help="contaminants & adapters FASTA (default: %(default)s)",
-                                         default="file-BXF0vYQ0QyBF509G9J12g927")
+# argparser.add_argument("--contaminants", help="contaminants & adapters FASTA (default: %(default)s)",
+#                                          default="file-BXF0vYQ0QyBF509G9J12g927")
 argparser.add_argument("--novocraft", help="Novocraft tarball (default: %(default)s)",
                                       default="file-BXJvFq00QyBKgFj9PZBqgbXg")
 argparser.add_argument("--gatk", help="GATK tarball (default: %(default)s)",
                                  default="file-BXK8p100QyB0JVff3j9Y1Bf5")
 argparser.add_argument("--run-tests", help="run small test assemblies", action="store_true")
 argparser.add_argument("--run-large-tests", help="run test assemblies of varying sizes", action="store_true")
-group = argparser.add_argument_group("filter")
-group.add_argument("--filter-targets", help="panel of target sequences (default: %(default)s)",
-                                default="file-BXF0vf80QyBF509G9J12g9F2")
-group = argparser.add_argument_group("scaffold")
-group.add_argument("--scaffold-reference", help="Reference genome FASTA (default: %(default)s)",
-                                            default="file-BXF0vZ00QyBF509G9J12g944")
+# group = argparser.add_argument_group("filter")
+# group.add_argument("--filter-targets", help="panel of target sequences (default: %(default)s)",
+#                                 default="file-BXF0vf80QyBF509G9J12g9F2")
+# group = argparser.add_argument_group("scaffold")
+# group.add_argument("--scaffold-reference", help="Reference genome FASTA (default: %(default)s)",
+#                                             default="file-BXF0vZ00QyBF509G9J12g944")
 args = argparser.parse_args()
 
 # detect git revision
@@ -62,14 +82,14 @@ def find_applet(applet_name):
                                      project=project.get_id(), folder=applets_folder,
                                      zero_ok=False, more_ok=False, return_handler=True)
 
-def build_workflow():
-    wf = dxpy.new_dxworkflow(title='viral-ngs-assembly',
-                              name='viral-ngs-assembly',
-                              description='viral-ngs-assembly',
+def build_workflow(species, resources):
+    wf = dxpy.new_dxworkflow(title='viral-ngs-assembly_{0}'.format(species),
+                              name='viral-ngs-assembly_{0}'.format(species),
+                              description='viral-ngs-assembly, with resources populated for {0}'.format(species),
                               project=args.project,
                               folder=args.folder,
                               properties={"git_revision": git_revision})
-    
+
     depletion_applet = find_applet("viral-ngs-human-depletion")
     depletion_applet_inputSpec = depletion_applet.describe()["inputSpec"]
     depletion_input = {
@@ -82,25 +102,31 @@ def build_workflow():
     filter_input = {
         "reads": dxpy.dxlink({"stage": depletion_stage_id, "outputField": "cleaned_reads"}),
         "min_base_count": 500000,
-        "targets": dxpy.dxlink(args.filter_targets),
         "resources": dxpy.dxlink({"stage": depletion_stage_id, "inputField": "resources"})
     }
+    if "filter-targets" in resources:
+        filter_input["targets"] = dxpy.dxlink(resources["filter-targets"])
+
     filter_stage_id = wf.add_stage(find_applet("viral-ngs-filter"), stage_input=filter_input, name="filter", folder="intermediates")
 
     trinity_input = {
         "reads": dxpy.dxlink({"stage": filter_stage_id, "outputField": "filtered_reads"}),
-        "contaminants": dxpy.dxlink(args.contaminants),
         "subsample": 100000,
         "resources": dxpy.dxlink({"stage": depletion_stage_id, "inputField": "resources"})
     }
+    if "contaminants" in resources:
+        trinity_input["contaminants"] = dxpy.dxlink(resources["contaminants"])
+
     trinity_stage_id = wf.add_stage(find_applet("viral-ngs-trinity"), stage_input=trinity_input, name="trinity", folder="intermediates")
 
     scaffold_input = {
         "trinity_contigs": dxpy.dxlink({"stage": trinity_stage_id, "outputField": "contigs"}),
         "trinity_reads": dxpy.dxlink({"stage": trinity_stage_id, "outputField": "subsampled_reads"}),
-        "reference_genome" : dxpy.dxlink(args.scaffold_reference),
         "resources": dxpy.dxlink({"stage": depletion_stage_id, "inputField": "resources"})
     }
+    if "scaffold-reference" in resources:
+        scaffold_input["reference_genome"] = dxpy.dxlink(resources["scaffold-reference"])
+
     scaffold_stage_id = wf.add_stage(find_applet("viral-ngs-assembly-scaffolding"), stage_input=scaffold_input, name="scaffold", folder="intermediates")
 
     refine1_input = {
@@ -137,7 +163,11 @@ def build_workflow():
 if args.no_applets is not True:
     build_applets()
 
-workflow = build_workflow()
+# Dict of species-name: workflow_id
+workflows = {}
+for species in args.species:
+    workflow = build_workflow(species, species_resource[species])
+    workflows[species] = workflow
 
 if args.run_tests is True or args.run_large_tests is True:
     muscle_applet = dxpy.DXApplet("applet-BXQxjv00QyB9QF3vP4BpXg95")
@@ -145,6 +175,7 @@ if args.run_tests is True or args.run_large_tests is True:
     # test data found in "bi-viral-ngs CI:/test_data"
     test_samples = {
         "SRR1553416": {
+            "species": "Ebola",
             "reads": "file-BXBP0VQ011y0B0g5bbJFzx51",
             "reads2": "file-BXBP0Xj011yFYvPjgJJ0GzZB",
             "broad_assembly": "file-BXFqQvQ0QyB5859Vpx1j7bqq",
@@ -154,6 +185,7 @@ if args.run_tests is True or args.run_large_tests is True:
             "expected_alignment_base_count": 485406
         },
         "SRR1553554": {
+            "species": "Ebola",
             "reads": "file-BXPPQ2Q0YzB28x9Q9911Ykz5",
             "reads2": "file-BXPPQ380YzB6xGxJ45K9Yv6Q",
             "broad_assembly": "file-BXQx6G00QyB6PQVYKQBgzxv4",
@@ -161,12 +193,22 @@ if args.run_tests is True or args.run_large_tests is True:
             # contig is named >SRR1553554-0
             "expected_subsampled_base_count":  467842,
             "expected_alignment_base_count": 590547
+        },
+        "G1190": {
+            "species": "Lassa",
+            "reads": "file-Bg97bJQ0x0z12q4XyZf5p0Kk",
+            "broad_assembly": 'file-Bg533J00x0zBkYkFGb23k58B',
+            "expected_assembly_sha256sum": "e7aa592e5ab9d3d1d3ac7fa1cc53eeff37e3ea30afad72a3cf9549172767c95c",
+            # contig is named >G1190-0 and so on
+            "expected_subsampled_base_count":  1841634,
+            "expected_alignment_base_count": 111944259
         }
     }
 
     if args.run_large_tests is True:
         # nb this sample takes too long for Travis
         test_samples["SRR1553468"] = {
+            "species": "Ebola",
             "reads": "file-BXYqZj80Fv4YqP151Zy9291y",
             "reads2": "file-BXYqZkQ0Fv4YZYKx14yJg0b4",
             "broad_assembly": "file-BXYqYKQ0QyB84xYJP9Kz7zzK",
@@ -182,13 +224,21 @@ if args.run_tests is True or args.run_large_tests is True:
         test_folder = args.folder + "/" + test_sample
         project.new_folder(test_folder)
         # run the workflow on the test sample
+        try:
+            workflow = workflows[test_samples[test_sample]["species"]]
+        except KeyError:
+            # Skip running test if workflow for req species was not built
+            continue
+
         test_input = {
             "deplete.file": dxpy.dxlink(test_samples[test_sample]["reads"]),
-            "deplete.paired_fastq": dxpy.dxlink(test_samples[test_sample]["reads2"]),
             "deplete.skip_depletion": True,
             "scaffold.novocraft_tarball": dxpy.dxlink(args.novocraft),
             "scaffold.gatk_tarball": dxpy.dxlink(args.gatk),
         }
+        if "reads2" in test_samples[test_sample]:
+            test_input["deplete.paired_fastq"] = dxpy.dxlink(test_samples[test_sample]["reads2"])
+
         test_analysis = workflow.run(test_input, project=project.get_id(), folder=test_folder, name=(git_revision+" "+test_sample))
         print "Launched {} for {}".format(test_analysis.get_id(), test_sample)
         test_analyses.append((test_sample,test_analysis))
@@ -232,7 +282,7 @@ if args.run_tests is True or args.run_large_tests is True:
         alignment_base_count = test_analysis.describe()["output"][workflow.get_stage("analysis")["id"]+".alignment_base_count"]
         expected_alignment_base_count = test_samples[test_sample]["expected_alignment_base_count"]
         print "\t".join([test_sample, "alignment_base_count", str(expected_alignment_base_count), str(alignment_base_count)])
-        
+
         assert expected_sha256sum == test_assembly_sha256sum
         assert expected_subsampled_base_count == subsampled_base_count
         assert expected_alignment_base_count == alignment_base_count

--- a/build_assembly_workflow.py
+++ b/build_assembly_workflow.py
@@ -148,8 +148,9 @@ if args.run_tests is True or args.run_large_tests is True:
             "reads": "file-BXBP0VQ011y0B0g5bbJFzx51",
             "reads2": "file-BXBP0Xj011yFYvPjgJJ0GzZB",
             "broad_assembly": "file-BXFqQvQ0QyB5859Vpx1j7bqq",
-            # "expected_assembly_sha256sum": "411834d66c5226651493b9b921a157984db030a3a5d048975b709806228d3806",
-            "expected_assembly_sha256sum": "20943d9e7e10208dd04cab6b9af2f27e8c924550921e0596fd4bddb1bfa827c1",
+            "expected_assembly_sha256sum": "411834d66c5226651493b9b921a157984db030a3a5d048975b709806228d3806",
+            # SHA256sum for fasta file with _scaffold suffix in contig name
+            # "expected_assembly_sha256sum": "20943d9e7e10208dd04cab6b9af2f27e8c924550921e0596fd4bddb1bfa827c1",
             "expected_subsampled_base_count": 459632,
             "expected_alignment_base_count": 485406
         },
@@ -157,8 +158,9 @@ if args.run_tests is True or args.run_large_tests is True:
             "reads": "file-BXPPQ2Q0YzB28x9Q9911Ykz5",
             "reads2": "file-BXPPQ380YzB6xGxJ45K9Yv6Q",
             "broad_assembly": "file-BXQx6G00QyB6PQVYKQBgzxv4",
-            # "expected_assembly_sha256sum": "af4328b04113a149e66055c113ef35fa566e691a2eabde85231ccf2a08df1bf4",
-            "expected_assembly_sha256sum": "5893354fad5088d0731bd0e3b9427b0a175743d283469d687c5d5b2004f1da89",
+            "expected_assembly_sha256sum": "af4328b04113a149e66055c113ef35fa566e691a2eabde85231ccf2a08df1bf4",
+            # SHA256sum for fasta file with _scaffold suffix in contig name
+            # "expected_assembly_sha256sum": "5893354fad5088d0731bd0e3b9427b0a175743d283469d687c5d5b2004f1da89",
             "expected_subsampled_base_count":  467842,
             "expected_alignment_base_count": 590547
         }
@@ -170,10 +172,9 @@ if args.run_tests is True or args.run_large_tests is True:
             "reads": "file-BXYqZj80Fv4YqP151Zy9291y",
             "reads2": "file-BXYqZkQ0Fv4YZYKx14yJg0b4",
             "broad_assembly": "file-BXYqYKQ0QyB84xYJP9Kz7zzK",
-            ## NOTE: THIS SHA256SUM HAS NOT BEEN DOUBLE-CHECKED AFTER THE CHROM_NAME FIELD WAS REMOVED
-            ## THE PREVIOUS OUTPUT CAN BE FOUND AT project-BXBXK180x0z7x5kxq11p886f:/file-BY2KVVj07xvkYVjyz10bxyKV
-            "expected_assembly_sha256sum": "4f851bfb1f3affd96e73dc20c4087e59908092a0354e3f00427c6bdfbf39d1a1",
-            # "expected_assembly_sha256sum": "456bd7e050222e0eff4fbe4a04c4124695c89d0533b318a49777789f3ed8bb2b",
+            "expected_assembly_sha256sum": "456bd7e050222e0eff4fbe4a04c4124695c89d0533b318a49777789f3ed8bb2b",
+            # SHA256sum for fasta file with _scaffold suffix in contig name
+            # "expected_assembly_sha256sum": "4f851bfb1f3affd96e73dc20c4087e59908092a0354e3f00427c6bdfbf39d1a1",
             "expected_subsampled_base_count": 18787806,
             "expected_alignment_base_count": 247110236
         }

--- a/build_assembly_workflow.py
+++ b/build_assembly_workflow.py
@@ -148,7 +148,8 @@ if args.run_tests is True or args.run_large_tests is True:
             "reads": "file-BXBP0VQ011y0B0g5bbJFzx51",
             "reads2": "file-BXBP0Xj011yFYvPjgJJ0GzZB",
             "broad_assembly": "file-BXFqQvQ0QyB5859Vpx1j7bqq",
-            "expected_assembly_sha256sum": "411834d66c5226651493b9b921a157984db030a3a5d048975b709806228d3806",
+            # "expected_assembly_sha256sum": "411834d66c5226651493b9b921a157984db030a3a5d048975b709806228d3806",
+            "expected_assembly_sha256sum": "20943d9e7e10208dd04cab6b9af2f27e8c924550921e0596fd4bddb1bfa827c1",
             "expected_subsampled_base_count": 459632,
             "expected_alignment_base_count": 485406
         },
@@ -156,7 +157,8 @@ if args.run_tests is True or args.run_large_tests is True:
             "reads": "file-BXPPQ2Q0YzB28x9Q9911Ykz5",
             "reads2": "file-BXPPQ380YzB6xGxJ45K9Yv6Q",
             "broad_assembly": "file-BXQx6G00QyB6PQVYKQBgzxv4",
-            "expected_assembly_sha256sum": "af4328b04113a149e66055c113ef35fa566e691a2eabde85231ccf2a08df1bf4",
+            # "expected_assembly_sha256sum": "af4328b04113a149e66055c113ef35fa566e691a2eabde85231ccf2a08df1bf4",
+            "expected_assembly_sha256sum": "5893354fad5088d0731bd0e3b9427b0a175743d283469d687c5d5b2004f1da89",
             "expected_subsampled_base_count":  467842,
             "expected_alignment_base_count": 590547
         }
@@ -168,7 +170,10 @@ if args.run_tests is True or args.run_large_tests is True:
             "reads": "file-BXYqZj80Fv4YqP151Zy9291y",
             "reads2": "file-BXYqZkQ0Fv4YZYKx14yJg0b4",
             "broad_assembly": "file-BXYqYKQ0QyB84xYJP9Kz7zzK",
-            "expected_assembly_sha256sum": "456bd7e050222e0eff4fbe4a04c4124695c89d0533b318a49777789f3ed8bb2b",
+            ## NOTE: THIS SHA256SUM HAS NOT BEEN DOUBLE-CHECKED AFTER THE CHROM_NAME FIELD WAS REMOVED
+            ## THE PREVIOUS OUTPUT CAN BE FOUND AT project-BXBXK180x0z7x5kxq11p886f:/file-BY2KVVj07xvkYVjyz10bxyKV
+            "expected_assembly_sha256sum": "4f851bfb1f3affd96e73dc20c4087e59908092a0354e3f00427c6bdfbf39d1a1",
+            # "expected_assembly_sha256sum": "456bd7e050222e0eff4fbe4a04c4124695c89d0533b318a49777789f3ed8bb2b",
             "expected_subsampled_base_count": 18787806,
             "expected_alignment_base_count": 247110236
         }

--- a/build_assembly_workflow.py
+++ b/build_assembly_workflow.py
@@ -41,14 +41,26 @@ print "project: {} ({})".format(project.name, args.project)
 print "folder: {}".format(args.folder)
 
 def build_applets():
-    applets = ["viral-ngs-human-depletion", "viral-ngs-filter", "viral-ngs-trinity", "viral-ngs-assembly-scaffolding", "viral-ngs-assembly-refinement", "viral-ngs-assembly-analysis"]
+    applets = ["viral-ngs-human-depletion", "viral-ngs-filter", "viral-ngs-trinity", "viral-ngs-assembly-scaffolding",
+               "viral-ngs-assembly-refinement", "viral-ngs-assembly-analysis"]
 
+    # Build applets for assembly workflow in [args.folder]/applets/ folder
     project.new_folder(applets_folder, parents=True)
     for applet in applets:
         # TODO: reuse an existing applet with matching git_revision
         print "building {}...".format(applet),
         sys.stdout.flush()
         applet_dxid = json.loads(subprocess.check_output(["dx","build","--destination",args.project+":"+applets_folder+"/",os.path.join(here,applet)]))["id"]
+        print applet_dxid
+        applet = dxpy.DXApplet(applet_dxid, project=project.get_id())
+        applet.set_properties({"git_revision": git_revision})
+
+    # Build applets that user interact with directly in [args.folder]/ main folder
+    exposed_applets = ["viral-ngs-fasta-fetcher"]
+    for applet in exposed_applets:
+        print "building {}...".format(applet),
+        sys.stdout.flush()
+        applet_dxid = json.loads(subprocess.check_output(["dx","build","--destination",args.project+":"+args.folder+"/",os.path.join(here,applet)]))["id"]
         print applet_dxid
         applet = dxpy.DXApplet(applet_dxid, project=project.get_id())
         applet.set_properties({"git_revision": git_revision})
@@ -69,7 +81,7 @@ def build_workflow():
                               project=args.project,
                               folder=args.folder,
                               properties={"git_revision": git_revision})
-    
+
     depletion_applet = find_applet("viral-ngs-human-depletion")
     depletion_applet_inputSpec = depletion_applet.describe()["inputSpec"]
     depletion_input = {
@@ -234,7 +246,7 @@ if args.run_tests is True or args.run_large_tests is True:
         alignment_base_count = test_analysis.describe()["output"][workflow.get_stage("analysis")["id"]+".alignment_base_count"]
         expected_alignment_base_count = test_samples[test_sample]["expected_alignment_base_count"]
         print "\t".join([test_sample, "alignment_base_count", str(expected_alignment_base_count), str(alignment_base_count)])
-        
+
         assert expected_sha256sum == test_assembly_sha256sum
         assert expected_subsampled_base_count == subsampled_base_count
         assert expected_alignment_base_count == alignment_base_count

--- a/viral-ngs-assembly-refinement/src/code.sh
+++ b/viral-ngs-assembly-refinement/src/code.sh
@@ -21,7 +21,6 @@ main() {
     novocraft/novoindex assembly.nix assembly.fasta
     python viral-ngs/assembly.py refine_assembly assembly.fasta reads.bam refined_assembly.fasta \
         --outVcf sites.vcf.gz --min_coverage "$min_coverage" --novo_params "$novoalign_options" \
-        --chr_names "${name%.refined}" # TODO: handle multiple contigs correctly
 
     dx-jobutil-add-output assembly_sites_vcf --class=file \
         $(zcat sites.vcf.gz | dx upload --destination "${name}.refinement.vcf" --brief -)

--- a/viral-ngs-assembly-scaffolding/dxapp.json
+++ b/viral-ngs-assembly-scaffolding/dxapp.json
@@ -23,7 +23,7 @@
     },
     {
       "name": "trinity_reads",
-      "help": "Reads given to Trinity",
+      "help": "Subsampled Reads from Trinity",
       "class": "file",
       "patterns": ["*.bam"]
     },

--- a/viral-ngs-assembly-scaffolding/dxapp.json
+++ b/viral-ngs-assembly-scaffolding/dxapp.json
@@ -39,10 +39,10 @@
       "optional": true
     },
     {
-      "name": "min_length",
-      "help": "Fail if the assembly is below this length",
-      "class": "int",
-      "default": 15000
+      "name": "min_length_fraction",
+      "help": "Fail if the assembly is below this fraction of the target reference",
+      "class": "float",
+      "default": 0.9
     },
     {
       "name": "min_unambig",

--- a/viral-ngs-assembly-scaffolding/src/code.sh
+++ b/viral-ngs-assembly-scaffolding/src/code.sh
@@ -24,7 +24,7 @@ main() {
     exit_code=0
     python viral-ngs/assembly.py impute_from_reference \
         vfat_scaffold.fasta reference_genome.fasta scaffold.fasta \
-        --newName "${name}_scaffold" --replaceLength "$replace_length" \
+        --newName "${name}" --replaceLength "$replace_length" \
         --minLengthFraction "$min_length_fraction" --minUnambig "$min_unambig" \
             2> >(tee impute.stderr.log >&2) || exit_code=$?
 

--- a/viral-ngs-assembly-scaffolding/src/code.sh
+++ b/viral-ngs-assembly-scaffolding/src/code.sh
@@ -25,12 +25,12 @@ main() {
     python viral-ngs/assembly.py impute_from_reference \
         vfat_scaffold.fasta reference_genome.fasta scaffold.fasta \
         --newName "${name}_scaffold" --replaceLength "$replace_length" \
-        --minLength "$min_length" --minUnambig "$min_unambig" \
+        --minLengthFraction "$min_length_fraction" --minUnambig "$min_unambig" \
             2> >(tee impute.stderr.log >&2) || exit_code=$?
 
     if [ "$exit_code" -ne "0" ]; then
         if grep PoorAssemblyError impute.stderr.log ; then
-            dx-jobutil-report-error "The assembly failed quality thresholds (length >= ${min_length}, non-N proportion >= ${min_unambig})" AppError
+            dx-jobutil-report-error "The assembly failed quality thresholds (length fraction >= ${min_length_fraction}, non-N proportion >= ${min_unambig})" AppError
         else
             dx-jobutil-report-error "Please check the job log" AppInternalError
         fi

--- a/viral-ngs-fasta-fetcher/Readme.md
+++ b/viral-ngs-fasta-fetcher/Readme.md
@@ -1,0 +1,11 @@
+# Viral NGS Fasta Fetcher
+
+## What does this applet do?
+
+This applet fetches genomic fasta files for organisms of given accession numbers from Genbank.
+
+## Parameters
+- resources: The tarball containing resources from the [viral-ngs project](https://github.com/broadinstitute/viral-ngs). This is typically pre-filled for your convenience.
+- accession_numbers: A list of NCBI accession numbers corresponding to the organisms/strains whose genomic fasta files are to be fetched. This can be provided as a space-delimited (NC_004296.1 NC_004297.1) or comma-delimited (NC_004296.1, NC_004297.1) string.
+- user_email: A valid email address is requested by NCBI for load/abuse notifications.
+- combined_genome_prefix: the output file will be named [combined_genome_prefix].fasta

--- a/viral-ngs-fasta-fetcher/dxapp.json
+++ b/viral-ngs-fasta-fetcher/dxapp.json
@@ -1,0 +1,51 @@
+{
+  "name": "viral-ngs-fasta-fetcher",
+  "title": "fetch_fasta",
+  "summary": "Fetch genomic fasta from Genbank based on accession numbers",
+  "dxapi": "1.0.0",
+  "version": "0.0.1",
+  "categories": [],
+  "inputSpec": [
+    {
+      "name": "accession_numbers",
+      "label": "Genbank accession numbers",
+      "class": "array:string",
+      "optional": false
+    },
+    {
+      "name": "combined_genome_prefix",
+      "label": "Prefix given to combined fasta file",
+      "class": "string",
+      "optional": false
+    },
+    {
+      "name": "user_email",
+      "label": "Email address passed to NCBI for notification of excessive requests",
+      "class": "string",
+      "optional": false
+    },
+    {
+      "name": "resources",
+      "class": "file",
+      "patterns": ["viral-ngs-*.resources.tar.gz"],
+      "default": {"$dnanexus_link": "file-Bg2VBvj0vFx512Ky6VG493Yz"}
+    }
+  ],
+  "outputSpec": [
+    {
+      "name": "genome_fasta",
+      "label": "Combined genome fasta",
+      "class": "file"
+    }
+  ],
+  "runSpec": {
+    "interpreter": "bash",
+    "file": "src/viral-ngs-fasta-fetcher.sh"
+  },
+  "access": {
+    "network": [
+      "*"
+    ]
+  },
+  "authorizedUsers": []
+}

--- a/viral-ngs-fasta-fetcher/src/viral-ngs-fasta-fetcher.sh
+++ b/viral-ngs-fasta-fetcher/src/viral-ngs-fasta-fetcher.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+main() {
+    set -e -x -o pipefail
+
+    accessions=$(echo ${accession_numbers[*]})
+    dx cat "$resources" | tar zx -C /
+
+    # Write combined fasta to /genome.fasta
+    viral-ngs/ncbi.py fetch_fastas_and_feature_tables $user_email ./ $accessions --combinedGenomeFilePrefix genome --removeSeparateFastas
+
+    genome_fasta=$(dx upload genome.fasta --destination "${combined_genome_prefix}.fasta" --brief)
+
+    dx-jobutil-add-output genome_fasta "$genome_fasta" --class=file
+}

--- a/viral-ngs-filter/src/viral-ngs-filter.sh
+++ b/viral-ngs-filter/src/viral-ngs-filter.sh
@@ -14,7 +14,7 @@ main() {
 
     # build Lastal target database to working dir with prefix targets.db
     # taxon_filter.py lastal_build_db [input_fasta] [output_dir] [output_prefix]
-    python viral-ngs/taxon_filter.py lastal_build_db targets.fasta ./ targets.db
+    python viral-ngs/taxon_filter.py lastal_build_db targets.fasta ./ --outputFilePrefix targets.db
     ls
     sha256sum targets.*
 

--- a/viral-ngs-filter/src/viral-ngs-filter.sh
+++ b/viral-ngs-filter/src/viral-ngs-filter.sh
@@ -12,8 +12,10 @@ main() {
     dx download "$reads" -o reads.bam
     for pid in "${pids[@]}"; do wait $pid || exit $?; done
 
-    # build Lastal target database
-    viral-ngs/tools/build/last-490/bin/lastdb targets.db targets.fasta
+    # build Lastal target database to working dir with prefix targets.db
+    # taxon_filter.py lastal_build_db [input_fasta] [output_dir] [output_prefix]
+    python viral-ngs/taxon_filter.py lastal_build_db targets.fasta ./ targets.db
+    ls
     sha256sum targets.*
 
     # filter the reads

--- a/viral-ngs-human-depletion/dxapp.json
+++ b/viral-ngs-human-depletion/dxapp.json
@@ -53,7 +53,7 @@
       "name": "resources",
       "class": "file",
       "patterns": ["viral-ngs-*.resources.tar.gz"],
-      "default": {"$dnanexus_link": "file-Bg19bfQ07JxbK9391vVBJFV7"}
+      "default": {"$dnanexus_link": "file-Bg2VBvj0vFx512Ky6VG493Yz"}
     }
   ],
   "outputSpec": [


### PR DESCRIPTION
@alphabdiallo 
cc @mlin 

This branch edits the existing viral-ngs pipeline to handle multi-contig genome such as that of the Lassa virus.

Tried this pipeline on the [sample provided by Chris](https://www.broadinstitute.org/~tomkinsc/lasv/) and was able to reproduce the expected assembly ~~(modulo difference in the naming of the scaffold: local version names it >G1190-0, DNAnexus version names it G1190_scaffold-0)~~.

Edit 8/17: Fixed scaffold naming convention

Note: the file `lassa.fasta` in assets is used, for the time being, as input for both the `filter` and `scaffold` steps. Eventually, we would envision providing a fasta file with a larger number of strains for the `filter` step.

Example usage: [lassa assembly run](https://platform.dnanexus.com/projects/BXBXK180x0z7x5kxq11p886f/monitor/analysis/Bg73Xbj0x0zJzZxxg04j7Xbv)
## TODO:

~~Edit build workflow to generate workflow with Lassa-specific input / add validation data~~
