### PR TITLE
Ct fasta fetch wrapper update

### DIFF
--- a/viral-ngs-fasta-fetcher/src/viral-ngs-fasta-fetcher.sh
+++ b/viral-ngs-fasta-fetcher/src/viral-ngs-fasta-fetcher.sh
@@ -14,14 +14,12 @@ main() {
     # if a command is present (even if arguments are missing), we can use exit codes
     # to determine the correct functions to call
 
-    viral-ngs/ncbi.py fetch_fastas_and_feature_tables &> /dev/null
-    if [[ $? -eq 0 ]] ; then
+    if viral-ngs/ncbi.py fetch_fastas_and_feature_tables &> /dev/null ; then
         # this is the old interface
         viral-ngs/ncbi.py fetch_fastas_and_feature_tables $user_email ./ $accessions --combinedGenomeFilePrefix genome --removeSeparateFastas
     fi
 
-    viral-ngs/ncbi.py fetch_fastas &> /dev/null
-    if [[ $? -eq 0 ]] ; then
+    if viral-ngs/ncbi.py fetch_fastas &> /dev/null ; then
         # this is the new interface
         viral-ngs/ncbi.py fetch_fastas $user_email ./ $accessions --combinedFilePrefix genome --removeSeparateFiles
         # if feature tables are needed, uncomment this:

--- a/viral-ngs-fasta-fetcher/src/viral-ngs-fasta-fetcher.sh
+++ b/viral-ngs-fasta-fetcher/src/viral-ngs-fasta-fetcher.sh
@@ -7,7 +7,26 @@ main() {
     dx cat "$resources" | tar zx -C /
 
     # Write combined fasta to /genome.fasta
-    viral-ngs/ncbi.py fetch_fastas_and_feature_tables $user_email ./ $accessions --combinedGenomeFilePrefix genome --removeSeparateFastas
+
+    # there is a change to the interface for fetching fastas, feature tables, and full GenBank records
+    # we need to check which commands are present and call them as appropriate.
+    # since argparse returns an error code if a command is missing, and exits zero
+    # if a command is present (even if arguments are missing), we can use exit codes
+    # to determine the correct functions to call
+
+    viral-ngs/ncbi.py fetch_fastas_and_feature_tables &> /dev/null
+    if [[ $? -eq 0 ]] ; then
+        # this is the old interface
+        viral-ngs/ncbi.py fetch_fastas_and_feature_tables $user_email ./ $accessions --combinedGenomeFilePrefix genome --removeSeparateFastas
+    fi
+
+    viral-ngs/ncbi.py fetch_fastas &> /dev/null
+    if [[ $? -eq 0 ]] ; then
+        # this is the new interface
+        viral-ngs/ncbi.py fetch_fastas $user_email ./ $accessions --combinedFilePrefix genome --removeSeparateFiles
+        # if feature tables are needed, uncomment this:
+        #viral-ngs/ncbi.py fetch_feature_tables $user_email ./ $accessions
+    fi
 
     genome_fasta=$(dx upload genome.fasta --destination "${combined_genome_prefix}.fasta" --brief)
 


### PR DESCRIPTION
@tomkinsc

cc @alphabdiallo @mlin 

Original PR: #5; applied patch to DNAnexus fork instead of remote branch for unpacking of `secure` Travis environment variable used for DNAnexus login and job initiation.

Note to self. TODO: add automatic testing of fasta-fetcher applet to Travis.
