### PR TITLE
Update tests to the travis unit and integration tests used upstream.

### DIFF
--- a/viral-ngs-builder/src/viral-ngs-builder.sh
+++ b/viral-ngs-builder/src/viral-ngs-builder.sh
@@ -29,7 +29,21 @@ main() {
 
     # build viral-ngs
     pip install -r requirements.txt
-    ./run_all_tests.sh
+    pip install nose
+
+    # Tool installation test
+    python -m unittest -v test.unit.test_tools.TestToolsInstallation
+
+    # Unit and integration test
+    nosetests -v --with-xunit --with-coverage --nocapture \
+    --cover-inclusive --cover-branches --cover-tests \
+    --cover-package broad_utils,illumina,assembly,interhost,intrahost,ncbi,read_utils,reports,taxon_filter,tools,util \
+    -w test/unit/
+
+    nosetests -v --with-xunit --with-coverage --nocapture \
+    --cover-inclusive --cover-branches --cover-tests \
+    --cover-package broad_utils,illumina,assembly,interhost,intrahost,ncbi,read_utils,reports,taxon_filter,tools,util \
+    -w test/integration/
 
     # record a new filesystem manifest
     (find / -type f 2> /dev/null || true) | sort > /tmp/fs-manifest.1


### PR DESCRIPTION
@mlin cc @alphabdiallo 
## Changes in this PR

The regression test regime in `viral-ngs-builder` applet is updated to echo the CI tests used by upstream repo in the files [install-tools](https://github.com/broadinstitute/viral-ngs/blob/master/travis/install-tools.sh), [test-long](https://github.com/broadinstitute/viral-ngs/blob/master/travis/tests-long.sh) and [test-unit](https://github.com/broadinstitute/viral-ngs/blob/master/travis/tests-unit.sh) found in the `/travis` folder respectively.
## Additional Changes

The updated `viral-ngs-builder` applet as per this PR was dx built and a copy was placed in the `resources_tarball` [folder](https://platform.dnanexus.com/projects/BXBXK180x0z7x5kxq11p886f/data/resources_tarball) of the `bi-viral-ngs-CI` project. This updated version of `viral-ngs-builder` will be used in calls to `build_resources_tarball.py` when the `--reuse-builder` flag is set to `true`.
