### PR TITLE
demux plus: keep multi-lane outputs organized by lane

### DIFF
--- a/viral-ngs-bwa-count-hits/src/viral-ngs-bwa-count-hits.sh
+++ b/viral-ngs-bwa-count-hits/src/viral-ngs-bwa-count-hits.sh
@@ -21,10 +21,16 @@ main() {
 
     # Output file name / directory wrangling
     sample_name="${in_bam_prefix}"
-    sample_out_fn="${out_fn}"
-
+    sample_out_fn="$out_fn"
     if [ "$per_sample_output" == "true" ]; then
-        out_dir="$out_dir/$sample_name"
+        # folder structure for multi-lane outputs uses lane metadata recorded
+        # in BAM property at the end of demux
+        lane=$(dx describe --json "$in_bam" | jq -r .properties.lane)
+        if [ "$lane" == "null" ]; then
+            out_dir="$out_dir/$sample_name"
+        else
+            out_dir="$out_dir/lane_$lane/$sample_name"
+        fi
         mkdir -p "$out_dir"
     else
         sample_out_fn="$sample_name.$out_fn"

--- a/viral-ngs-classification/src/viral-ngs-classification.sh
+++ b/viral-ngs-classification/src/viral-ngs-classification.sh
@@ -74,8 +74,17 @@ function main() {
     # will not gain much.
     dx cat "${mappings[$i]}" > ~/scratch/"${mappings_name[$i]}"
 
+    # folder structure for multi-lane outputs uses lane metadata recorded
+    # in BAM property at the end of demux
+    lane=$(dx describe --json "${mappings[$i]}" | jq -r .properties.lane)
+    if [ "$lane" == "null" ]; then
+        output_root_dir=~/"out/outputs/"
+    else
+        output_root_dir=~/"out/outputs/lane_$lane/"
+    fi
+
     output_filename_prefix="${mappings_prefix[$i]%.cleaned}"
-    output_root_dir=~/"out/outputs/$output_filename_prefix"
+    output_root_dir="${output_root_dir}$output_filename_prefix"
     mkdir -p "$output_root_dir"/
 
     # Load viral-ngs virtual environment

--- a/viral-ngs-count-hits-multiplex/src/viral-ngs-count-hits-multiplex.sh
+++ b/viral-ngs-count-hits-multiplex/src/viral-ngs-count-hits-multiplex.sh
@@ -56,7 +56,14 @@ main() {
 
         fastqc_dest=""
         if [ "$per_sample_output" == "true" ]; then
-            fastqc_dest="/$bam_name"
+            # folder structure for multi-lane outputs uses lane metadata recorded
+            # in BAM property at the end of demux
+            lane=$(dx describe --json "$bam" | jq -r .properties.lane)
+            if [ "$lane" == "null" ]; then
+                fastqc_dest="/$bam_name"
+            else
+                fastqc_dest="/lane_$lane/$bam_name"
+            fi
         fi
 
         fastqc_job_id=$(dx run $fastqc_applet_id \

--- a/viral-ngs-count-hits/src/viral-ngs-count-hits.sh
+++ b/viral-ngs-count-hits/src/viral-ngs-count-hits.sh
@@ -35,9 +35,16 @@ main() {
 
     # Output file name / directory wrangling
     sample_name="${in_bam_prefix}"
-    sample_out_fn=$out_fn
+    sample_out_fn="$out_fn"
     if [ "$per_sample_output" == "true" ]; then
-        out_dir="$out_dir/$sample_name"
+        # folder structure for multi-lane outputs uses lane metadata recorded
+        # in BAM property at the end of demux
+        lane=$(dx describe --json "$in_bam" | jq -r .properties.lane)
+        if [ "$lane" == "null" ]; then
+            out_dir="$out_dir/$sample_name"
+        else
+            out_dir="$out_dir/lane_$lane/$sample_name"
+        fi
         mkdir -p "$out_dir"
     else
         sample_out_fn="$sample_name.$out_fn"

--- a/viral-ngs-demux/src/viral-ngs-demux.sh
+++ b/viral-ngs-demux/src/viral-ngs-demux.sh
@@ -221,4 +221,19 @@ main() {
 
     dx-upload-all-outputs
 
+    # add flowcell and lane properties to bams
+    for lane in ${lanes[@]}; do
+        bam_out_dir="/"
+        if [ "$multi_lane" = true ]; then
+            bam_out_dir="/lane_$lane"
+        fi
+        for dxfile in $(dx find data --folder "$bam_out_dir" --class file --brief); do
+            if [ -n "$flowcell" ]; then
+                dx set_properties "$dxfile" "flowcell=$flowcell"
+            fi
+            if [ "$multi_lane" = true ]; then
+                dx set_properties "$dxfile" "lane=$lane"
+            fi
+        done
+    done
 }

--- a/viral-ngs-human-depletion/src/code.sh
+++ b/viral-ngs-human-depletion/src/code.sh
@@ -174,8 +174,16 @@ main() {
     intermediates_out_folder="out/intermediates"
 
     if [ "$per_sample_output" == "true" ]; then
-        cleaned_reads_out_folder="out/cleaned_reads/${sample_name}"
-        intermediates_out_folder="out/intermediates/${sample_name}"
+        # folder structure for multi-lane outputs uses lane metadata recorded
+        # in BAM property at the end of demux
+        lane=$(dx describe --json "$file" | jq -r .properties.lane)
+        if [ "$lane" == "null" ]; then
+            cleaned_reads_out_folder="out/cleaned_reads/${sample_name}"
+            intermediates_out_folder="out/intermediates/${sample_name}"
+        else
+            cleaned_reads_out_folder="out/cleaned_reads/lane_$lane/${sample_name}"
+            intermediates_out_folder="out/intermediates/lane_$lane/${sample_name}"
+        fi
     fi
 
     mkdir -p $cleaned_reads_out_folder


### PR DESCRIPTION
Particularly, avoids conflation when a sample is sequenced on >1 lanes of the same run
