### PR TITLE
extend instance autoscaling to support HiSeq4000-size runs

### DIFF
--- a/demux/viral-ngs-demux-wrapper/src/viral-ngs-demux-wrapper.sh
+++ b/demux/viral-ngs-demux-wrapper/src/viral-ngs-demux-wrapper.sh
@@ -42,24 +42,19 @@ main() {
         # total data size more roughly tracks total tile count
         total_tile_count=$((lane_count*surface_count*swath_count*tile_count))
 
-        case $total_tile_count in
-            28)
-                instance_type="mem1_ssd1_x4"
-                echo "Detected $total_tile_count tiles, interpreting as MiSeq run, executing on a $instance_type machine."
-            ;;
-            128)
-                instance_type="mem1_ssd2_x4"
-                echo "Detected $total_tile_count tiles, interpreting as HiSeq2k run, executing on a $instance_type machine."
-            ;;
-            896)
-                instance_type="mem1_hdd2_x32"
-                echo "Detected $total_tile_count tiles, interpreting as HiSeq4k run, executing on a $instance_type machine."
-            ;;
-            *)
-                instance_type="mem1_ssd1_x4"
-                echo "Tile count: $total_tile_count tiles, (unknown instrument type), executing on a $instance_type machine."
-            ;;
-        esac
+        if [ "$total_tile_count" -le 50 ]; then 
+            instance_type="mem1_ssd1_x4"
+            echo "Detected $total_tile_count tiles, interpreting as MiSeq run, executing on a $instance_type machine."
+        elif [ "$total_tile_count" -ge 49 -a "$total_tile_count" -le 150 ]; then 
+            instance_type="mem1_ssd2_x4"
+            echo "Detected $total_tile_count tiles, interpreting as HiSeq2k run, executing on a $instance_type machine."
+        elif [ "$total_tile_count" -ge 149 -a "$total_tile_count" -le 896 ]; then 
+            instance_type="mem1_hdd2_x32"
+            echo "Detected $total_tile_count tiles, interpreting as HiSeq4k run, executing on a $instance_type machine."
+        elif [ "$total_tile_count" -ge 895 ]; then 
+            instance_type="mem1_hdd2_x32"
+            echo "Tile count: $total_tile_count tiles, (unknown instrument type), executing on a $instance_type machine."
+        fi
     fi
 
     if [ "$upload_sentinel_record" == "" ] && [ "$is_hiseq" == 'true' ];

--- a/demux/viral-ngs-demux-wrapper/src/viral-ngs-demux-wrapper.sh
+++ b/demux/viral-ngs-demux-wrapper/src/viral-ngs-demux-wrapper.sh
@@ -45,13 +45,13 @@ main() {
         if [ "$total_tile_count" -le 50 ]; then 
             instance_type="mem1_ssd1_x4"
             echo "Detected $total_tile_count tiles, interpreting as MiSeq run, executing on a $instance_type machine."
-        elif [ "$total_tile_count" -ge 49 -a "$total_tile_count" -le 150 ]; then 
+        elif [ "$total_tile_count" -gt 50 -a "$total_tile_count" -le 150 ]; then 
             instance_type="mem1_ssd2_x4"
             echo "Detected $total_tile_count tiles, interpreting as HiSeq2k run, executing on a $instance_type machine."
-        elif [ "$total_tile_count" -ge 149 -a "$total_tile_count" -le 896 ]; then 
+        elif [ "$total_tile_count" -gt 150 -a "$total_tile_count" -le 896 ]; then 
             instance_type="mem1_hdd2_x32"
             echo "Detected $total_tile_count tiles, interpreting as HiSeq4k run, executing on a $instance_type machine."
-        elif [ "$total_tile_count" -ge 895 ]; then 
+        elif [ "$total_tile_count" -gt 896 ]; then 
             instance_type="mem1_hdd2_x32"
             echo "Tile count: $total_tile_count tiles, (unknown instrument type), executing on a $instance_type machine."
         fi

--- a/demux/viral-ngs-demux-wrapper/src/viral-ngs-demux-wrapper.sh
+++ b/demux/viral-ngs-demux-wrapper/src/viral-ngs-demux-wrapper.sh
@@ -60,6 +60,7 @@ main() {
                 echo "Lane count: $total_tile_count tiles, (unknown instrument type), executing on a $instance_type machine."
             ;;
         esac
+    fi
 
     if [ "$upload_sentinel_record" == "" ] && [ "$is_hiseq" == 'true' ];
     then

--- a/demux/viral-ngs-demux-wrapper/src/viral-ngs-demux-wrapper.sh
+++ b/demux/viral-ngs-demux-wrapper/src/viral-ngs-demux-wrapper.sh
@@ -45,10 +45,10 @@ main() {
         if [ "$total_tile_count" -le 50 ]; then 
             instance_type="mem1_ssd1_x4"
             echo "Detected $total_tile_count tiles, interpreting as MiSeq run, executing on a $instance_type machine."
-        elif [ "$total_tile_count" -gt 50 -a "$total_tile_count" -le 150 ]; then 
+        elif [ "$total_tile_count" -le 150 ]; then 
             instance_type="mem1_ssd2_x4"
             echo "Detected $total_tile_count tiles, interpreting as HiSeq2k run, executing on a $instance_type machine."
-        elif [ "$total_tile_count" -gt 150 -a "$total_tile_count" -le 896 ]; then 
+        elif [ "$total_tile_count" -le 896 ]; then 
             instance_type="mem1_hdd2_x32"
             echo "Detected $total_tile_count tiles, interpreting as HiSeq4k run, executing on a $instance_type machine."
         elif [ "$total_tile_count" -gt 896 ]; then 

--- a/demux/viral-ngs-demux-wrapper/src/viral-ngs-demux-wrapper.sh
+++ b/demux/viral-ngs-demux-wrapper/src/viral-ngs-demux-wrapper.sh
@@ -57,7 +57,7 @@ main() {
             ;;
             *)
                 instance_type="mem1_ssd1_x4"
-                echo "Lane count: $total_tile_count tiles, (unknown instrument type), executing on a $instance_type machine."
+                echo "Tile count: $total_tile_count tiles, (unknown instrument type), executing on a $instance_type machine."
             ;;
         esac
     fi


### PR DESCRIPTION
extend instance type autoscaling to support HiSeq4000-size runs; instance size is now scaled based on total flowcell tile count rather than only number of lanes