### PR TITLE
improve / fix figures of merit in analysis applet

### DIFF
--- a/assembly/viral-ngs-assembly-analysis/dxapp.json
+++ b/assembly/viral-ngs-assembly-analysis/dxapp.json
@@ -87,6 +87,10 @@
       "class": "int"
     },
     {
+      "name": "assembly_length_unambiguous",
+      "class": "int"
+    },
+    {
       "name": "alignment_read_count",
       "class": "int"
     },

--- a/assembly/viral-ngs-assembly-analysis/src/code.sh
+++ b/assembly/viral-ngs-assembly-analysis/src/code.sh
@@ -34,7 +34,8 @@ main() {
     viral-ngs reports.py plot_coverage /user-data/mapped.bam /user-data/coverage_plot.pdf --plotFormat pdf --plotWidth 1100 --plotHeight 850 --plotDPI 100
 
     # collect some statistics
-    assembly_length=$(tail -n +1 assembly.fasta | tr -d '\n' | wc -c)
+    assembly_length=$(grep -v '^>' assembly.fasta | tr -d '\n' | wc -c)
+    assembly_length_unambiguous=$(grep -v '^>' assembly.fasta | tr -d '\nNn' | wc -c)
     alignment_read_count=$(samtools view -c mapped.bam)
     reads_paired_count=$(samtools flagstat all.bam | grep properly | awk '{print $1}')
     alignment_base_count=$(samtools view mapped.bam | cut -f10 | tr -d '\n' | wc -c)
@@ -46,6 +47,7 @@ main() {
 
     # upload outputs
     dx-jobutil-add-output assembly_length $assembly_length
+    dx-jobutil-add-output assembly_length_unambiguous $assembly_length_unambiguous
     dx-jobutil-add-output reads_paired_count $reads_paired_count
     dx-jobutil-add-output alignment_read_count $alignment_read_count
     dx-jobutil-add-output alignment_base_count $alignment_base_count


### PR DESCRIPTION
fix assembly_length counting for multi-segment genomes and add a new metric that counts unambigious bases as well